### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -31,6 +31,8 @@ jobs:
           path: dist/
 
   checks:
+    permissions:
+      contents: read
     uses: ./.github/workflows/shared.yml
 
   pypi-publish:


### PR DESCRIPTION
Potential fix for [https://github.com/ReuelAlbert-Dev/python-sdk/security/code-scanning/4](https://github.com/ReuelAlbert-Dev/python-sdk/security/code-scanning/4)

To fix the problem, we should add a `permissions` block to the `checks` job in `.github/workflows/publish-pypi.yml`. Since the `checks` job likely only needs read access (for running tests, linting, etc.), we can set `contents: read` as a minimal starting point. This change should be made directly under the `checks:` job definition, before the `uses:` line. No additional imports or definitions are needed; this is a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
